### PR TITLE
Fixed the following:

### DIFF
--- a/animations/src/App.css
+++ b/animations/src/App.css
@@ -117,7 +117,7 @@
 }
 
 .node-partition {
-	r: 60;
+	/* r: 60; */
 	fill: transparent;
 	stroke-dasharray: 5;
 	stroke: black;
@@ -131,17 +131,8 @@
 }
 .stale-data-text {
 	fill: red;
-	animation: blink 1s linear infinite;
 }
 
-@keyframes blinker {
-  50% {
-    opacity: 0;
-  }
-}
-
-@keyframes blink{
-0%{opacity: 0;}
-50%{opacity: 0;}
-100%{opacity: 1;}
+#node-c-partition-wrap text {
+	font-size: 14px;
 }

--- a/animations/src/RaftReadOperationAnimation.js
+++ b/animations/src/RaftReadOperationAnimation.js
@@ -1,0 +1,103 @@
+
+import React, { Component } from 'react';
+import './App.css';
+import anime from 'animejs/lib/anime.es.js';
+import MainDiagram from './svg/MainDiagram';
+import {Constants} from './constants';
+
+var HelperFunctions = require('./HelperFunctions');
+
+
+const ANIMATION_STATE_INITIAL = "RAFT_READ_OPERATION_INITIAL";
+const ANIMATION_STATE_CLIENT_INTRODUCED = "ANIMATION_STATE_CLIENT_INTRODUCED";
+const ANIMATION_STATE_PERFORMED_READ_ON_LEADER = "ANIMATION_STATE_PERFORMED_READ_ON_LEADER";
+const ANIMATION_STATE_LEADER_RECEIVED_MAJORITY_ON_VALUE_FROM_FOLLOWERS = "ANIMATION_STATE_LEADER_RECEIVED_MAJORITY_ON_VALUE_FROM_FOLLOWERS";
+
+const SET_VALUE1="V1";
+const SET_VALUE2="V2";
+function setValueText(value) {
+	return "SET " + value;
+}
+
+export class RaftReadOperationAnimation extends Component {
+	constructor(props) {
+		super(props);
+		this.animationState = ANIMATION_STATE_INITIAL;
+	}
+
+	componentDidMount() {
+		this.mainTextSect = document.getElementById('main-text-sect');
+		HelperFunctions.delayedNext(this,100);
+	}
+
+	next() {
+		switch(this.animationState) {
+			case ANIMATION_STATE_INITIAL: {
+				//////////////////// initial setup ////////////////////
+				// make Node C the Leader
+				var nodeC = document.getElementById('node-c-circle');
+				nodeC.classList.add('leader-node');
+
+				// hide all outer circles (TODO: revisit this approach)
+				var nodeOuterCircles = document.getElementsByClassName('node-outer-circle');
+				for (var i = 0; i < nodeOuterCircles.length; i++){
+					HelperFunctions.hideElement(nodeOuterCircles[i]);
+				}
+				//////////////////////////////////////////////////////
+				this.changeMainText('Read problem solution in Raft ...', () => {
+					var introduceClientAnimation = HelperFunctions.introduceClient(SET_VALUE1);
+					introduceClientAnimation.finished.then(() => {
+						this.animationState = ANIMATION_STATE_CLIENT_INTRODUCED;
+						HelperFunctions.delayedNext(this, 100);
+					})
+				});
+				break;
+			}
+			case ANIMATION_STATE_CLIENT_INTRODUCED: {
+				this.changeMainText('Client performs a read operation', () => {
+					var animation = HelperFunctions.sendLogMessage(Constants.CLIENT_NODE, Constants.NODE_C, false);
+					this.animationState = ANIMATION_STATE_PERFORMED_READ_ON_LEADER;
+					HelperFunctions.delayedNext(this, 1000);
+				});
+				break;
+			}
+			case ANIMATION_STATE_PERFORMED_READ_ON_LEADER: {
+				this.changeMainText('Leader contacts followers to obtain a consensus on current value', () => {
+					var animation = HelperFunctions.logMessageFromLeaderToFollowers(true);
+					this.animationState = ANIMATION_STATE_LEADER_RECEIVED_MAJORITY_ON_VALUE_FROM_FOLLOWERS;
+					HelperFunctions.delayedNext(this, 1000);
+				});
+				break;
+			}
+			case ANIMATION_STATE_LEADER_RECEIVED_MAJORITY_ON_VALUE_FROM_FOLLOWERS: {
+				this.changeMainText('Once majority is obtained. The leader returns value back to the client', () => {
+					var animation = HelperFunctions.sendLogMessage(Constants.NODE_C, Constants.CLIENT_NODE);
+				});
+				break;
+			}
+			default:
+				console.error('Unrecognized state: ' + this.animationState);
+		}
+	}
+	changeMainText(text, onComplete) {
+		HelperFunctions.setTextWithAnimation(this.mainTextSect, text, onComplete);
+	}
+
+	changeMainText(text, onComplete) {
+		HelperFunctions.setTextWithAnimation(this.mainTextSect, text, onComplete);
+	}
+
+	render() {
+		return(
+			<div>
+				<div id="main-diagram">
+					<MainDiagram/>
+				</div>
+				<div id="main-text-sect">
+				</div>
+			</div>
+		)
+	}
+}
+
+export default RaftReadOperationAnimation;

--- a/animations/src/constants.js
+++ b/animations/src/constants.js
@@ -2,6 +2,7 @@ export var Constants = {
 	DEFAULT_DELAY: 2000,
 	NODE_A: "NODE_A",
 	NODE_B: "NODE_B",
+	NODE_C: "NODE_C",
 	CLIENT_NODE: "CLIENT_NODE",
 
 }

--- a/animations/src/svg/MainDiagram.js
+++ b/animations/src/svg/MainDiagram.js
@@ -57,7 +57,14 @@ class MainDiagram extends Component {
 				{/* node C */}
 
 				{/* partition around C */}
-				<circle id="node-c-partition" className="node-partition visibility-hidden" cx={nodeCXPos+32} cy={nodeCYPos} />
+
+				<g id="node-c-partition-wrap" className="visibility-hidden">
+					<path d="M210,340a83.832377,83.832377,0,1,1,111,30" id="node-c-partition" className="node-partition"/>
+					<text fill="black">
+						<tspan x="240" y="240">Partitioned</tspan>
+						<tspan x="240" y="260">from A & B</tspan>
+					</text>
+				</g>
 
 				{/* main and outer circles */}
 				<g id="node-c-wrap">
@@ -71,7 +78,7 @@ class MainDiagram extends Component {
 				{/* text */}
 				<text x={nodeCXPos} y={nodeCYPos} fill="black">
 					<tspan x={nodeCXPos + 6} y={nodeCYPos + 84}>Node C</tspan>
-					<tspan x={nodeCXPos + 6} y={nodeCYPos + 102}>Term: 0</tspan>
+					<tspan id="node-c-term-text" x={nodeCXPos + 6} y={nodeCYPos + 102}>Term: 0</tspan>
 					<tspan id="node-c-extra-text" className="node-extra-text visibility-hidden" x={nodeCXPos + 6} y={nodeCYPos + 120}>Vote Count: 1</tspan>
 				</text>
 
@@ -89,7 +96,7 @@ class MainDiagram extends Component {
 				{/* text */}
 				<text x={nodeAPositions.base.x} y={nodeAPositions.base.y + 66} fill="black">
 					<tspan x={nodeAPositions.base.x - 24} y={nodeAPositions.base.y + 84}>Node A</tspan>
-					<tspan x={nodeAPositions.base.x - 24} y={nodeAPositions.base.y + 102}>Term: 0</tspan>
+					<tspan id="node-a-term-text" x={nodeAPositions.base.x - 24} y={nodeAPositions.base.y + 102}>Term: 0</tspan>
 					<tspan id="node-a-extra-text" className="node-extra-text visibility-hidden" x={nodeAPositions.base.x - 24} y={nodeAPositions.base.y + 120}>Voted For: C</tspan>
 
 				</text>
@@ -97,7 +104,7 @@ class MainDiagram extends Component {
 				{/* node B */}
 				<text x={nodeBXPos} y={nodeBYPos} fill="black">
 					<tspan x={nodeBXPos} y={nodeBYPos + 18}>Node B</tspan>
-					<tspan x={nodeBXPos} y={nodeBYPos + 36}>Term: 0</tspan>
+					<tspan id="node-b-term-text" x={nodeBXPos} y={nodeBYPos + 36}>Term: 0</tspan>
 					<tspan id="node-b-extra-text" className="node-extra-text visibility-hidden" x={nodeBXPos} y={nodeBYPos + 54}>Voted For: C</tspan>
 				</text>
 


### PR DESCRIPTION
1. In all animations, the uncommitted set 5 show show up as soon as the message is received
2. In all animations, make sure we respond to client on successful completion
3. Partition should show C getting cut off from A and B, but not from client.
4. Stop blinking animation in read operation failure. Just show in red
5. When new leader gets elected term should be set to 1

Also implemented  Raft's solution to the read problem