### PR TITLE
Fixed the following

### DIFF
--- a/animations/src/App.css
+++ b/animations/src/App.css
@@ -7,11 +7,6 @@
   color: #61dafb;
 }
 
-/* #main-text-sect,
-#main-btn-sect {
-	padding-left: 150px;
-	padding-right: 150px;
-} */
 #main-text-sect {
 	max-width: 420px;
 	padding-left: 18px;

--- a/animations/src/App.js
+++ b/animations/src/App.js
@@ -22,17 +22,42 @@ class App extends Component {
     return (
 			<Router>
 		    <div className="App">
+					<Route exact path='/' component={Home}></Route>
+
 					<Route exact path='/raft-write-operation' render={(props) => <AnimationRunner {...props} animationToRun={RaftWriteAnimation}/> }></Route>
+
           <Route exact path='/why-raft-read-fails-without-quorum' render={(props) => <AnimationRunner {...props} animationToRun={ReadFailureAnimation}/> }></Route>
 
 					<Route exact path='/raft-read-with-leader-leases' render={(props) => <AnimationRunner {...props} animationToRun={LeaderLeasesAnimation}/> }></Route>
 
 					<Route exact path='/read-operation-in-raft' render={(props) => <AnimationRunner {...props} animationToRun={RaftReadOperationAnimation}/> }></Route>
-
 		    </div>
 			</Router>
     );
   }
+}
+
+class Home extends Component {
+	render() {
+		return (
+			<div>
+				<ul>
+					<li>
+						<Link to="/raft-write-operation">Raft write operation</Link>
+					</li>
+					<li>
+						<Link to="/why-raft-read-fails-without-quorum">Why raft read failes without quorum</Link>
+					</li>
+					<li>
+						<Link to="/read-operation-in-raft">Read operation in raft</Link>
+					</li>
+					<li>
+						<Link to="/raft-read-with-leader-leases">Raft read with leader leases</Link>
+					</li>
+				</ul>
+			</div>
+		);
+	}
 }
 
 

--- a/animations/src/HelperFunctions.js
+++ b/animations/src/HelperFunctions.js
@@ -75,7 +75,7 @@ export function introduceClient(clientTextValue) {
 	}
 	var animation = anime({
 		targets: clientNode,
-		translateY: -72
+		translateY: -84
 	});
 	return animation;
 }
@@ -89,12 +89,12 @@ export function messageFromClient(destination, params) {
 	switch (destination) {
 		case Constants.NODE_C: {
 			translateX = 100;
-			translateY = -100;
+			translateY = -120;
 			break;
 		}
 		case Constants.NODE_A: {
 			translateX = -160;
-			translateY = -120;
+			translateY = -156;
 			break;
 		}
 		default: {
@@ -117,24 +117,26 @@ export function messageFromClient(destination, params) {
 	return animation;
 }
 
-export function logMessageFromAToB(withAck) {
-	return sendLogMessage(Constants.NODE_A, Constants.NODE_B, withAck);
-}
-
 export function sendLogMessage(fromNode, toNode, withAck, value, commitValue, delay, destinationTimerAnimation, srcTimerAnimation) {
 	console.log('FromNode: ' + fromNode + " toNode: " + toNode + " withAck: " + withAck + " value: " + value + " commitValue: " + commitValue);
 	var method = null;
 	var messageElement = null;
 	var textElementId = null;
 	var sourceNodeTextElementId = null;
+	var messageContrainer = null;
+	var additionalTextElementID = null;
+	var sourceNodeAdditionalTextElementId = null;
+
 	switch(fromNode) {
 		case Constants.NODE_A: {
 			method = messageFromA;
 			sourceNodeTextElementId = 'node-a-extra-text';
+			sourceNodeAdditionalTextElementId = 'node-a-extra-text2';
 
 			if(toNode == Constants.NODE_B) {
 				messageElement = document.getElementById('node-a-message-to-b');
 				textElementId = 'node-b-extra-text';
+				additionalTextElementID = 'node-b-extra-text2';
 			} else if (toNode == Constants.CLIENT_NODE) {
 				messageElement = document.getElementById('node-a-message-to-client');
 			}
@@ -143,13 +145,16 @@ export function sendLogMessage(fromNode, toNode, withAck, value, commitValue, de
 		case Constants.NODE_C: {
 			method = messageFromC;
 			sourceNodeTextElementId = 'node-c-extra-text';
+			sourceNodeAdditionalTextElementId = 'node-c-extra-text2';
 
 			if (toNode == Constants.NODE_A) {
 				messageElement = document.getElementById('node-c-message-to-a');
 				textElementId = 'node-a-extra-text';
+				additionalTextElementID = 'node-a-extra-text2';
 			} else if (toNode == Constants.NODE_B) {
 				messageElement = document.getElementById('node-c-message-to-b');
 				textElementId = 'node-b-extra-text';
+				additionalTextElementID = 'node-b-extra-text2';
 			} else if (toNode == Constants.CLIENT_NODE) {
 				messageElement = document.getElementById('node-c-message-to-client');
 			}
@@ -157,15 +162,18 @@ export function sendLogMessage(fromNode, toNode, withAck, value, commitValue, de
 		}
 		case Constants.CLIENT_NODE: {
 			method = messageFromClient;
+			messageElement = document.getElementById('client-message-circle');
+			messageContrainer = document.getElementById('client-message');
+
 			if (toNode == Constants.NODE_A) {
-				messageElement = document.getElementById('client-message');
 				textElementId = 'node-a-extra-text';
+				additionalTextElementID = 'node-a-extra-text2';
 			} else if (toNode == Constants.NODE_B) {
-				messageElement = document.getElementById('client-message');
 				textElementId = 'node-b-extra-text';
+				additionalTextElementID = 'node-b-extra-text2';
 			} else if (toNode == Constants.NODE_C) {
-				messageElement = document.getElementById('client-message');
 				textElementId = 'node-c-extra-text';
+				additionalTextElementID = 'node-c-extra-text2';
 			}
 			break;
 		}
@@ -193,15 +201,18 @@ export function sendLogMessage(fromNode, toNode, withAck, value, commitValue, de
 					messageElement.classList.add('log-message-ack');
 				}
 
+				var additionalText = null;
 				if (value && textElementId){
 					var addCSSClass = "";
 					var removeCSSClass = "";
 					if (commitValue) {
 						addCSSClass = "set-text-committed";
 						removeCSSClass = "set-text-uncommitted";
+						additionalText = Constants.COMMITED;
 					} else {
 						addCSSClass = "set-text-uncommitted";
 						removeCSSClass = "set-text-committed";
+						additionalText = Constants.UNCOMMITED;
 					}
 
 					setSVGText({
@@ -211,20 +222,39 @@ export function sendLogMessage(fromNode, toNode, withAck, value, commitValue, de
 						removeCSSClass:removeCSSClass,
 						showElement: true,
 					});
+
+					console.log('additionalText: ' + additionalText + 'additionalTextElementID: ' + additionalTextElementID);
+					if (additionalText != null && additionalTextElementID){
+						console.log('will update additionalText');
+						setSVGText({
+							targetId: additionalTextElementID,
+							text: additionalText,
+							addCSSClass: addCSSClass,
+							removeCSSClass:removeCSSClass,
+							showElement: true,
+						});
+					}
 				}
 			},
 			onComplete: anim => {
 				if (withAck) {
 					messageElement.classList.remove('log-message-ack');
 					// we got the ack back so uncommited text should be shown as commited now
-					if (sourceNodeTextElementId) {
+					if (value && sourceNodeTextElementId) {
 						setSVGText({targetId: sourceNodeTextElementId, addCSSClass: "set-text-committed"});
+					}
+					if (value && sourceNodeAdditionalTextElementId){
+						setSVGText({targetId: sourceNodeAdditionalTextElementId, text: Constants.COMMITED, addCSSClass: "set-text-committed"});
 					}
 				}
 				if (srcTimerAnimation) {
 					srcTimerAnimation.restart();
 				}
 				messageElement.style.transform = 'none';
+				if (messageContrainer) {
+					messageContrainer.style.transform = 'none';
+				}
+
 			},
 			alternate: withAck,
 		});
@@ -254,7 +284,7 @@ export function messageFromC(destination, params) {
 	var targets = "";
 	if (destination == Constants.NODE_B) {
 		translateX = -132;
-		translateY = -220;
+		translateY = -290;
 		targets = '#node-c-message-to-b';
 	} else if (destination == Constants.NODE_A) {
 		targets = '#node-c-message-to-a';
@@ -262,7 +292,7 @@ export function messageFromC(destination, params) {
 	} else if (destination == Constants.CLIENT_NODE) {
 		targets = '#node-c-message-to-client';
 		translateX = -100;
-		translateY = 100;
+		translateY = 130;
 	}
 
 	var animation = anime({
@@ -286,12 +316,12 @@ export function messageFromA(destination, params) {
 	var targets = "";
 	if (destination == Constants.NODE_B) {
 		translateX = 160;
-		translateY = -200;
+		translateY = -290;
 		targets = '#node-a-message-to-b';
 	}
 	else if (destination == Constants.CLIENT_NODE) {
 		translateX = 150;
-		translateY = 100;
+		translateY = 148;
 		targets = '#node-a-message-to-client';
 	}
 	else {
@@ -316,7 +346,7 @@ export function messageFromA(destination, params) {
 }
 
 export function getSetValueText(value) {
-	return "SET " + value;
+	return "Value: " + value;
 }
 
 export function partitionNodeC() {
@@ -324,21 +354,39 @@ export function partitionNodeC() {
 	showElement(nodeCPartition);
 }
 
-export function startLeaseTimer(forNode, duration){
-	var targetId = constructTimerElementId(forNode);
+export function startMyLeaseTimer(forNode, duration){
+	var targetId = myLeaseTimerId(forNode);
+	return startLeaseTimer(targetId, forNode, duration);
+}
+export function startLeaderLeaseTimer(forNode, duration){
+	var targetId = leaderLeaseTimerId(forNode);
+	return startLeaseTimer(targetId, forNode, duration);
+}
+
+export function startLeaseTimer(targetId, forNode, duration){
 	var timer = document.getElementById(targetId);
-	showElement(timer)
+	showElement(timer);
+
+	var innerRect = document.getElementById(targetId + '-inner');
 	var animation = anime({
-		targets: timer,
+		targets: innerRect,
 		width: '0',
-		easing: 'easeInOutQuad',
+		easing: 'easeOutCubic',
 		duration: duration,
 	});
 	return animation;
 }
 
-export function constructTimerElementId(forNode) {
-	var id = "htimer-rect-";
+export function myLeaseTimerId(forNode) {
+	return constructTimerId("mlease-rect-", forNode);
+}
+
+export function leaderLeaseTimerId(forNode) {
+	return constructTimerId("llease-rect", forNode);
+}
+
+function constructTimerId(prefix, forNode) {
+	var id = prefix;
 	switch(forNode) {
 		case Constants.NODE_C: {
 			id += "node-c";

--- a/animations/src/RaftWriteAnimation.js
+++ b/animations/src/RaftWriteAnimation.js
@@ -191,29 +191,12 @@ class RaftWriteAnimation extends Component {
 				var introClientAnimation = HelperFunctions.introduceClient();
 
 				introClientAnimation.finished.then(() => {
-					var clientMessage = document.getElementById('client-message');
-					HelperFunctions.showElement(clientMessage);
-
-					var clientMessageAnimation = anime({
-						targets: '#client-message',
-						translateX: 100,
-						translateY: -100,
-						easing: 'linear',
-						duration: 800,
-					});
-					clientMessageAnimation.finished.then(() => {
-						HelperFunctions.setSVGText(
-							{
-								targetId: 'node-c-extra-text',
-								text: "SET 5",
-								addCSSClass: "set-text-uncommitted",
-								showElement: true,
-							}
-						);
+					var messageToCAnimation = HelperFunctions.sendLogMessage(Constants.CLIENT_NODE, Constants.NODE_C, false, HelperFunctions.getSetValueText(SET_VALUE1));
+					messageToCAnimation.finished.then(() => {
 						this.animationState = AnimationState.LOG_REPLICATION_MESSAGE_RECEIVED_BY_LEADER;
 						resolve({
 							animationState: this.animationState,
-							delay: 2000,
+							delay: 1000,
 						});
 					})
 				});
@@ -222,7 +205,7 @@ class RaftWriteAnimation extends Component {
 			case AnimationState.LOG_REPLICATION_MESSAGE_RECEIVED_BY_LEADER: {
 				this.changeMainText("The log entry is currently uncommitted, so it won't update the node's value. To commit the entry the node first replicates it to the follower nodes", () => {
 					// send log messages to follower nodes
-					var animations = HelperFunctions.logMessageFromLeaderToFollowers(true, "SET " + SET_VALUE1);
+					var animations = HelperFunctions.logMessageFromLeaderToFollowers(true, HelperFunctions.getSetValueText(SET_VALUE1));
 					var animationPromises = HelperFunctions.getFinishPromises(animations);
 
 					// wait for both animations to finish before proceeding
@@ -258,7 +241,7 @@ class RaftWriteAnimation extends Component {
 			case AnimationState.LOG_REPLICATION_LEADER_HAS_COMMITED_ENTRY: {
 				this.changeMainText("The leader then notifies followers and the client that entry is committed", () => {
 					// notify followers that leader has committed the entries
-					var animations = HelperFunctions.logMessageFromLeaderToFollowers(false,"SET " + SET_VALUE1, true);
+					var animations = HelperFunctions.logMessageFromLeaderToFollowers(false,HelperFunctions.getSetValueText(SET_VALUE1), true);
 					var animationPromises = HelperFunctions.getFinishPromises(animations);
 
 					// and notify client as well

--- a/animations/src/ReadFailureAnimation.js
+++ b/animations/src/ReadFailureAnimation.js
@@ -111,7 +111,7 @@ export class ReadOperationAnimation extends Component {
 			}
 			case ANIMATION_STATE_LEADER_RECEIVED_ACKS_FROM_FOLLOWERS: {
 				// next leader notifies followers that it has commited the entry
-				var animations = HelperFunctions.logMessageFromLeaderToFollowers(false,"SET " + SET_VALUE1, true, 600);
+				var animations = HelperFunctions.logMessageFromLeaderToFollowers(false,setValueText(SET_VALUE1), true, 600);
 				var finishPromises = HelperFunctions.getFinishPromises(animations);
 
 				// and notify client as well
@@ -197,18 +197,7 @@ export class ReadOperationAnimation extends Component {
 			}
 			case ANIMATION_STATE_POST_PARTITION_NODE_A_RECEIVED_ACK_FROM_NODE_B: {
 				// send commit confirmation back to B
-				var animation = HelperFunctions.sendLogMessage(Constants.NODE_A, Constants.NODE_B, false, SET_VALUE2, false, 600);
-				animation.finished.then(() => {
-					// mark B's SET operation as commited
-					HelperFunctions.setSVGText({
-							targetId: 'node-b-extra-text',
-							addCSSClass: "set-text-committed",
-					});
-					HelperFunctions.setSVGText({
-							targetId: 'node-b-main-text',
-							text: SET_VALUE2
-					});
-				});
+				HelperFunctions.sendLogMessage(Constants.NODE_A, Constants.NODE_B, false, setValueText(SET_VALUE2), true, 600);
 
 				// notify client as well
 				var messageToClientAnimation = HelperFunctions.sendLogMessage(Constants.NODE_A, Constants.CLIENT_NODE);

--- a/animations/src/constants.js
+++ b/animations/src/constants.js
@@ -5,5 +5,6 @@ export var Constants = {
 	NODE_C: "NODE_C",
 	CLIENT_NODE: "CLIENT_NODE",
 	ANIMATION_STATE_FINISHED: "ANIMATION_STATE_FINISHED",
-
+	COMMITED: "(commited)",
+	UNCOMMITED: "(uncommitted)",
 }

--- a/animations/src/svg/HorizontalTimer.js
+++ b/animations/src/svg/HorizontalTimer.js
@@ -8,21 +8,17 @@ class HorizontalTimer extends Component {
 	}
 	render() {
 		return (
-			<g transform="translate(10,10)">
-				<rect className={this.props.className} id={this.props.uid} x={this.props.x} y={this.props.y} width="80" height="6" rx="2.5" ry="2.55" strokeWidth="1px" fill="#333" stroke="555" />
+			<g transform="translate(10,10)" className={this.props.className} id={this.props.uid}>
+				<text x={this.props.x + 36} y={this.props.y - 4} fill="black">
+					{this.props.label}
+				</text>
+				<rect id={this.props.uid + '-inner'} x={this.props.x + 32} y={this.props.y} width="80" height="6" rx="2.5" ry="2.55" strokeWidth="1px" fill="#333" stroke="#555" />
+				<rect id={this.props.uid + '-outer'} x={this.props.x + 32} y={this.props.y} width="80" height="7" rx="2.5" ry="2.55" strokeWidth="2px" fill="transparent" stroke="black" />}
 			</g>
 		)
 	}
 	startTimer() {
-		// var targetId = "#"+ "htimer-rect-" + this.props.uid;
-		// console.log('Target Id: ' + targetId);
-		// var animation = anime({
-		// 	targets: targetId,
-		// 	width: '0%',
-		// 	easing: 'linear',
-		// 	duration: 2000,
-		// });
-		// return animation;
+		// TODO
 	}
 }
 

--- a/animations/src/svg/MainDiagram.js
+++ b/animations/src/svg/MainDiagram.js
@@ -14,10 +14,11 @@ const nodeABaseYPos = 324;
 const nodeCBaseXPos = 276;
 const nodeCBaseYPos = 324;
 
-const nodeBXPos = 168;
-const nodeBYPos = 18;
+const nodeBBaseXPos = 168;
+const nodeBBaseYPos = 42;
+
 const clientNodeXPos = 186;
-const clientNodeYPos = 498;
+const clientNodeYPos = 550;
 
 export const clientNodePositions = {
 	mainText: {
@@ -45,7 +46,7 @@ export const nodeAPositions = {
 	},
 	leaseTimer: {
 		x: nodeABaseXPos - 48,
-		y: nodeABaseYPos + 42
+		y: nodeABaseYPos + 108
 	}
 }
 
@@ -75,11 +76,19 @@ export const nodeCPositions = {
 		y: nodeCBaseYPos - 85
 	}
 }
+
+export const nodeBPositions = {
+	base: {
+		x: nodeBBaseXPos,
+		y: nodeBBaseYPos
+	},
+}
+
 class MainDiagram extends Component {
 
 	render() {
 		return (
-			<svg height="464" width="380">
+			<svg height="500" width="380">
 				{/* reusable analog clock */}
 				<defs>
 					<SmallClock/>
@@ -90,9 +99,12 @@ class MainDiagram extends Component {
 				<circle id="node-c-message-to-a" className="node-small-circle" cx={nodeCPositions.messageToA.x} cy={nodeCPositions.messageToB.y} />
 				<circle id="node-c-message-to-client" className="node-small-circle visibility-hidden" cx={nodeCPositions.messageToClient.x} cy={nodeCPositions.messageToClient.y} />
 
-				<circle id="client-message" className="client-message visibility-hidden" cx={clientNodePositions.clientMessage.x} cy={clientNodePositions.clientMessage.y}/>
+				<g id="client-message" className="visibility-hidden">
+					<circle id="client-message-circle" className="client-message" cx={clientNodePositions.clientMessage.x} cy={clientNodePositions.clientMessage.y}/>
+					<text id="client-message-text" x={clientNodePositions.clientMessage.x - 18} y={clientNodePositions.clientMessage.y + 24} />
+				</g>
 
-				<circle id="node-b-small-circle" className="node-small-circle" cx={nodeBXPos + 24} cy={nodeBYPos + 102} />
+				<circle id="node-b-small-circle" className="node-small-circle" cx={nodeBPositions.base.x + 24} cy={nodeBPositions.base.y + 12} />
 
 				<circle id="node-a-message-to-b" className="node-small-circle visibility-hidden" cx={nodeAPositions.messageToB.x} cy={nodeAPositions.messageToB.y} />
 				<circle id="node-a-message-to-client" className="node-small-circle visibility-hidden" cx={nodeAPositions.messageToClient.x} cy={nodeAPositions.messageToClient.y} />
@@ -103,6 +115,10 @@ class MainDiagram extends Component {
 				</g>
 				<g id="node-c-lease-to-node-b" className="visibility-hidden">
 					<use href="#analog-clock" x={nodeCPositions.base.x + 24} y={nodeCPositions.base.y - 36}/>
+				</g>
+
+				<g id="node-a-lease-to-node-b" className="">
+					<use href="#analog-clock" x={nodeAPositions.base.x} y={nodeAPositions.base.y - 36}/>
 				</g>
 
 				{/* node C */}
@@ -124,14 +140,18 @@ class MainDiagram extends Component {
 					<text id="node-c-main-text" x={nodeCPositions.base.x + 30} y={nodeCPositions.base.y + 6} className="node-text visibility-hidden" fill="black">
 						<tspan>5</tspan>
 					</text>
-					<HorizontalTimer className="visibility-hidden" uid={HelperFunctions.constructTimerElementId(Constants.NODE_C)} x={nodeCPositions.base.x - 18} y={nodeCPositions.base.y + 42}/>
+					<HorizontalTimer className="visibility-hidden" uid={HelperFunctions.myLeaseTimerId(Constants.NODE_C)} x={nodeCPositions.base.x - 48} y={nodeCPositions.base.y + 118}
+					label={"My Lease"}/>
+					<HorizontalTimer className="visibility-hidden" uid={HelperFunctions.leaderLeaseTimerId(Constants.NODE_C)} x={nodeCPositions.base.x - 48} y={nodeCPositions.base.y + 148}
+					label={"Leader Lease"}/>
 				</g>
 
 				{/* text */}
 				<text x={nodeCPositions.base.x} y={nodeCPositions.base.y} fill="black">
-					<tspan x={nodeCPositions.base.x + 6} y={nodeCPositions.base.y + 84}>Node C</tspan>
-					<tspan id="node-c-term-text" x={nodeCPositions.base.x + 6} y={nodeCPositions.base.y + 102}>Term: 0</tspan>
-					<tspan id="node-c-extra-text" className="node-extra-text visibility-hidden" x={nodeCPositions.base.x + 6} y={nodeCPositions.base.y + 120}>Vote Count: 1</tspan>
+					<tspan x={nodeCPositions.base.x + 6} y={nodeCPositions.base.y + 54}>Node C</tspan>
+					<tspan id="node-c-term-text" x={nodeCPositions.base.x + 6} y={nodeCPositions.base.y + 72}>Term: 0</tspan>
+					<tspan id="node-c-extra-text" className="node-extra-text visibility-hidden" x={nodeCPositions.base.x + 6} y={nodeCPositions.base.y + 90}>Vote Count: 1</tspan>
+					<tspan id="node-c-extra-text2" className="node-extra-text2 visibility-hidden" x={nodeCPositions.base.x - 6} y={nodeCPositions.base.y + 108} >FOO</tspan>
 				</text>
 
 				{/* node A */}
@@ -143,34 +163,38 @@ class MainDiagram extends Component {
 					<text id="node-a-main-text" x={nodeAPositions.base.x} y={nodeAPositions.base.y + 6} className="node-text visibility-hidden">
 						<tspan>5</tspan>
 					</text>
-					<HorizontalTimer className="visibility-hidden" uid={HelperFunctions.constructTimerElementId(Constants.NODE_A)} x={nodeAPositions.leaseTimer.x} y={nodeAPositions.leaseTimer.y}/>
+					<HorizontalTimer className="visibility-hidden" uid={HelperFunctions.myLeaseTimerId(Constants.NODE_A)} x={nodeAPositions.leaseTimer.x - 24} y={nodeAPositions.leaseTimer.y + 12} label={"My Lease"}/>
+					<HorizontalTimer className="visibility-hidden" uid={HelperFunctions.leaderLeaseTimerId(Constants.NODE_A)} x={nodeAPositions.leaseTimer.x - 24} y={nodeAPositions.leaseTimer.y + 42} label={"Leader Lease"}/>
 				</g>
 
 				{/* text */}
 				<text x={nodeAPositions.base.x} y={nodeAPositions.base.y + 66} fill="black">
-					<tspan x={nodeAPositions.base.x - 24} y={nodeAPositions.base.y + 84}>Node A</tspan>
-					<tspan id="node-a-term-text" x={nodeAPositions.base.x - 24} y={nodeAPositions.base.y + 102}>Term: 0</tspan>
-					<tspan id="node-a-extra-text" className="node-extra-text visibility-hidden" x={nodeAPositions.base.x - 24} y={nodeAPositions.base.y + 120}>Voted For: C</tspan>
+					<tspan x={nodeAPositions.base.x - 24} y={nodeAPositions.base.y + 54}>Node A</tspan>
+					<tspan id="node-a-term-text" x={nodeAPositions.base.x - 24} y={nodeAPositions.base.y + 72}>Term: 0</tspan>
+					<tspan id="node-a-extra-text" className="node-extra-text visibility-hidden" x={nodeAPositions.base.x - 24} y={nodeAPositions.base.y + 90}>Voted For: C</tspan>
+					<tspan id="node-a-extra-text2" className="node-extra-text2 visibility-hidden" x={nodeAPositions.base.x - 36} y={nodeAPositions.base.y + 108} ></tspan>
 
 				</text>
 
 				{/* node B */}
-				<text x={nodeBXPos} y={nodeBYPos} fill="black">
-					<tspan x={nodeBXPos} y={nodeBYPos + 18}>Node B</tspan>
-					<tspan id="node-b-term-text" x={nodeBXPos} y={nodeBYPos + 36}>Term: 0</tspan>
-					<tspan id="node-b-extra-text" className="node-extra-text visibility-hidden" x={nodeBXPos} y={nodeBYPos + 54}>Voted For: C</tspan>
-				</text>
-
 
 				{/* main and outer circles */}
 				<g id="node-b-wrap">
-					<circle id="node-b-circle" cx={nodeBXPos + 24} cy={nodeBYPos + 102} r="35" stroke="rgb(70, 130, 180)" strokeWidth="0" fill="rgb(70, 130, 180)" />
-					<circle id="node-b-outer-circle" className="node-outer-circle" cx={nodeBXPos + 24} cy={nodeBYPos + 102} r="35" stroke="rgb(70, 130, 180)" strokeWidth="14" fill="transparent" />
-					<text id="node-b-main-text" x={nodeBXPos + 24} y={nodeBYPos + 108} className="node-text visibility-hidden">
-						<tspan>5</tspan>
+					<circle id="node-b-circle" cx={nodeBPositions.base.x + 24} cy={nodeBPositions.base.y} r="35" stroke="rgb(70, 130, 180)" strokeWidth="0" fill="rgb(70, 130, 180)" />
+					<circle id="node-b-outer-circle" className="node-outer-circle" cx={nodeBPositions.base.x + 24} cy={nodeBPositions.base.y} r="35" stroke="rgb(70, 130, 180)" strokeWidth="14" fill="transparent" />
+					<text id="node-b-main-text" x={nodeBPositions.base.x + 24} y={nodeBPositions.base.y + 6} className="node-text visibility-hidden">
 					</text>
-					<HorizontalTimer className="visibility-hidden" uid={HelperFunctions.constructTimerElementId(Constants.NODE_B)} x={nodeBXPos - 24} y={nodeBYPos + 50}/>
+					<HorizontalTimer className="visibility-hidden" uid={HelperFunctions.myLeaseTimerId(Constants.NODE_B)} x={nodeBPositions.base.x - 54} y={nodeBPositions.base.y + 120} label={"My Lease"}/>
+					<HorizontalTimer className="visibility-hidden" uid={HelperFunctions.leaderLeaseTimerId(Constants.NODE_B)} x={nodeBPositions.base.x - 54} y={nodeBPositions.base.y + 148} label="Leader Lease"/>
 				</g>
+
+				{/* text */}
+				<text x={nodeBPositions.base.x} y={nodeBPositions.base.y} fill="black">
+					<tspan x={nodeBPositions.base.x} y={nodeBPositions.base.y + 54}>Node B</tspan>
+					<tspan id="node-b-term-text" x={nodeBPositions.base.x} y={nodeBPositions.base.y + 72}>Term: 0</tspan>
+					<tspan id="node-b-extra-text" className="node-extra-text visibility-hidden" x={nodeBPositions.base.x} y={nodeBPositions.base.y + 90}>Voted For: C</tspan>
+					<tspan id="node-b-extra-text2" className="node-extra-text2 visibility-hidden" x={nodeBPositions.base.x - 12} y={nodeBPositions.base.y + 108} ></tspan>
+				</text>
 
 				{/* client node */}
 				<g id="client-node">


### PR DESCRIPTION
- Leader lease timer should start earlier
- Add borders around the timers
- Partition and leader candidate should happen in two separate steps
- In reject message to client mention reject as text (in red)
- Label the timers
- All nodes should have my lease and leader lease timer slots. Label timers as leader lease and my lease (for leader)
- Fix orders to: Term, value(set part), leader lease,
- Change SET V1 to Value: V1 (for all nodes). Not committed values should be labeled
- During new leader election its timer needs to go to zero and it should then replicate a new lease
- Lease timer should not reset on client messages